### PR TITLE
Idle wait handled slightly different

### DIFF
--- a/MonikAI/Behaviours/IdleBehaviour.cs
+++ b/MonikAI/Behaviours/IdleBehaviour.cs
@@ -29,10 +29,10 @@ namespace MonikAI.Behaviours
         private List<KeyValuePair<string, (int, int)>> timeoutSpeeds = new List<KeyValuePair<string, (int, int)>>()
         {
             new KeyValuePair<string, (int, int)>("very short", (30, 120)),
-            new KeyValuePair<string, (int, int)>("short", (1, 3)),
-            new KeyValuePair<string, (int, int)>("regular", (2, 5)),
-            new KeyValuePair<string, (int, int)>("long", (3, 8)),
-            new KeyValuePair<string, (int, int)>("very long", (4, 10))
+            new KeyValuePair<string, (int, int)>("short", (60, 180)),
+            new KeyValuePair<string, (int, int)>("regular", (120, 300)),
+            new KeyValuePair<string, (int, int)>("long", (180, 480)),
+            new KeyValuePair<string, (int, int)>("very long", (240, 600))
         };
 
         public void Init(MainWindow window)
@@ -56,10 +56,7 @@ namespace MonikAI.Behaviours
         private void SetTimeOut()
         {
             var speed = timeoutSpeeds.Where(x => x.Key == MonikaiSettings.Default.IdleWait.ToLower()).FirstOrDefault();
-            if (speed.Key == "very short")
-                idleTimeout = new TimeSpan(0, 0, random.Next(speed.Value.Item1, speed.Value.Item2 + 1));
-            else
-                idleTimeout = new TimeSpan(0, random.Next(speed.Value.Item1, speed.Value.Item2 + 1), 0);
+            idleTimeout = TimeSpan.FromSeconds(random.Next(speed.Value.Item1, speed.Value.Item2 + 1));
         }
 
         /// <summary>

--- a/MonikAI/Behaviours/IdleBehaviour.cs
+++ b/MonikAI/Behaviours/IdleBehaviour.cs
@@ -28,7 +28,7 @@ namespace MonikAI.Behaviours
 
         private List<KeyValuePair<string, (int, int)>> timeoutSpeeds = new List<KeyValuePair<string, (int, int)>>()
         {
-            new KeyValuePair<string, (int, int)>("very short", (1, 2)),
+            new KeyValuePair<string, (int, int)>("very short", (30, 120)),
             new KeyValuePair<string, (int, int)>("short", (1, 3)),
             new KeyValuePair<string, (int, int)>("regular", (2, 5)),
             new KeyValuePair<string, (int, int)>("long", (3, 8)),
@@ -56,7 +56,10 @@ namespace MonikAI.Behaviours
         private void SetTimeOut()
         {
             var speed = timeoutSpeeds.Where(x => x.Key == MonikaiSettings.Default.IdleWait.ToLower()).FirstOrDefault();
-            idleTimeout = new TimeSpan(0, random.Next(speed.Value.Item1, speed.Value.Item2 + 1), 0);
+            if (speed.Key == "very short")
+                idleTimeout = new TimeSpan(0, 0, random.Next(speed.Value.Item1, speed.Value.Item2 + 1));
+            else
+                idleTimeout = new TimeSpan(0, random.Next(speed.Value.Item1, speed.Value.Item2 + 1), 0);
         }
 
         /// <summary>

--- a/MonikAI/MainWindow.xaml.cs
+++ b/MonikAI/MainWindow.xaml.cs
@@ -161,7 +161,9 @@ namespace MonikAI
                 this.updaterInitTask?.Wait();
                 await this.updater.PerformUpdate(this);
 
+#if DEBUG
                 MessageBox.Show("This is a testing build, please do me the favor and don't distribute it right now.");
+#endif
 
                 // Startup logic
                 if (MonikaiSettings.Default.FirstLaunch)


### PR DESCRIPTION
I've changed up the wait times for the idle delay to use seconds for a shorter option than a minute being the lowest.

I've also added a #if directive so that the message box will only show on a debug build so that publicly compiled release builds won't get that message box pop up.