### PR TITLE
Added temporary solution to word cut-off problem

### DIFF
--- a/MonikAI/Parsers/CSVParser.cs
+++ b/MonikAI/Parsers/CSVParser.cs
@@ -106,8 +106,30 @@ namespace MonikAI.Parsers
                     {
                         if (!string.IsNullOrWhiteSpace(columns[textCell].ToString()))
                         {
-                            // "a" face is default
-                            res.ResponseChain.Add(new Expression(columns[textCell].ToString(), string.IsNullOrWhiteSpace(columns[textCell + 1].ToString()) ? "a" : columns[textCell + 1].ToString()));
+                            var resText = columns[textCell].ToString();
+                            var responseLength = resText.Length;
+                            var face = string.IsNullOrWhiteSpace(columns[textCell + 1].ToString()) ? "a" : columns[textCell + 1].ToString(); // "a" face is default
+
+                            // If text can fit in a single box then add it to the response chain, otherwise break it up.
+                            while (responseLength > 0)
+                            {
+                                // The dialogue box capacity differs based on character width.
+                                // From some testing it seems like a max of 90 works fine in a lot of cases but this isn't a perfect solution.
+                                if (responseLength <= 90)
+                                {
+                                    res.ResponseChain.Add(new Expression(resText, face));
+                                    break;
+                                }
+                                else
+                                {
+                                    // Get next response segment and update remaining response
+                                    var responseSegment = resText.Substring(0, 90);
+                                    resText = resText.Substring(90).Trim();
+                                    responseLength = resText.Length;
+
+                                    res.ResponseChain.Add(new Expression(responseSegment.Trim(), face));
+                                }
+                            }
                         }
                     }
 


### PR DESCRIPTION
In order to try and solve the problem of text getting cut off, I just hardcoded a maximum limit to the number of characters that can fit into a single box and if a response exceeds that limit, it gets moved into a new entry in the same response chain so that it gets rendered on the next page.

This solution isn't ideal however because different characters have different widths. The character 'a' for example, takes up less space than the character 'Q' so this can lead to some edge cases where the text can still get cut off if there are enough characters that have a larger width, such as if a response is made entirely of capital letters.

I'm not entirely sure how to go about solving the problem for good since there isn't a set maximum for the number of characters that can fit on one line. I figured I'd put up a PR anyway since this seems to handle a lot of the currently existing responses fine from what I tested.