### PR TITLE
Change how MonikAI catch url in browser

### DIFF
--- a/MonikAI/App.config
+++ b/MonikAI/App.config
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="MonikAI.MonikaiSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
-            <section name="MonikAI.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+            <section name="MonikAI.MonikaiSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+            <section name="MonikAI.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
     </startup>
     <userSettings>
         <MonikAI.MonikaiSettings>
@@ -77,8 +77,16 @@
         </MonikAI.MonikaiSettings>
         <MonikAI.Settings>
             <setting name="LastStarted" serializeAs="String">
-                <value/>
+                <value />
             </setting>
         </MonikAI.Settings>
     </userSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/MonikAI/Behaviours/HttpRestServer/RestController.cs
+++ b/MonikAI/Behaviours/HttpRestServer/RestController.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using uhttpsharp;
+using uhttpsharp.Handlers;
+
+namespace receive_http_request_from_monkey_script
+{
+    class RestController : IRestController<string>
+    {
+        Action<String> changeURL;
+        public RestController(Action<String> a)
+        {
+            changeURL = a;
+        }
+
+        public Task<string> Create(IHttpRequest request)
+        {
+            return Task.FromResult("");
+        }
+
+        public Task<IEnumerable<string>> Get(IHttpRequest request)
+        {
+            return Task.FromResult<IEnumerable<string>>(new[] { "" });
+        }
+        public Task<string> GetItem(IHttpRequest request)
+        {
+            return Task.FromResult("");
+        }
+        public Task<string> Upsert(IHttpRequest request)
+        {
+            string result = System.Text.Encoding.UTF8.GetString(request.Post.Raw);
+            Console.WriteLine(result);
+
+            changeURL.Invoke(result);
+
+            return Task.FromResult(result);
+        }
+        public Task<string> Delete(IHttpRequest request)
+        {
+            return Task.FromResult("");
+        }
+    }
+}

--- a/MonikAI/Behaviours/HttpRestServer/UrlRestServer.cs
+++ b/MonikAI/Behaviours/HttpRestServer/UrlRestServer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Sockets;
+
+
+using uhttpsharp;
+using uhttpsharp.Handlers;
+using uhttpsharp.Listeners;
+using uhttpsharp.RequestProviders;
+
+using receive_http_request_from_monkey_script;
+
+namespace MonikAI.Behaviours.HttpRestServer
+{
+    class UrlRestServer
+    {
+        public static string URL { get => lastURL; }
+        static string lastURL = null;
+
+        //may be offset this to a thread?
+        public static Task StartServer()
+        {
+            var httpServer = new HttpServer(new HttpRequestProvider());
+
+            // listen to 127.0.0.1:82 :
+            httpServer.Use(new TcpListenerAdapter(new TcpListener(IPAddress.Loopback, 82)));
+
+            // Request handling : 
+            httpServer.Use((context, next) =>
+            {
+                return next();
+            });
+
+            // Handler request : 
+            httpServer.Use(new HttpRouter().With("monikai", new RestHandler<string>(new RestController((url) => lastURL = url), JsonResponseProvider.Default)));
+
+            httpServer.Start();
+
+            return Task.Run(() => httpServer.Dispose());
+        }
+    }
+}

--- a/MonikAI/MainWindow.xaml.cs
+++ b/MonikAI/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using Microsoft.Win32;
 using MonikAI.Behaviours;
+using MonikAI.Behaviours.HttpRestServer;
 using MonikAI.Parsers;
 using MessageBox = System.Windows.MessageBox;
 using Point = System.Drawing.Point;
@@ -75,6 +76,9 @@ namespace MonikAI
         public MainWindow()
         {
             this.InitializeComponent();
+
+            //start the rest server
+            UrlRestServer.StartServer();
 
             MainWindow.desktopWindow = MainWindow.GetDesktopWindow();
             MainWindow.shellWindow = MainWindow.GetShellWindow();

--- a/MonikAI/MonikAI.csproj
+++ b/MonikAI/MonikAI.csproj
@@ -86,6 +86,9 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
+    <Reference Include="uhttpsharp, Version=0.1.5653.28566, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\uHttpSharp.0.1.6.22\lib\net40\uhttpsharp.dll</HintPath>
+    </Reference>
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
@@ -98,6 +101,8 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Behaviours\ApplicationBehaviour.cs" />
+    <Compile Include="Behaviours\HttpRestServer\RestController.cs" />
+    <Compile Include="Behaviours\HttpRestServer\UrlRestServer.cs" />
     <Compile Include="Behaviours\IBehaviour.cs" />
     <Compile Include="Behaviours\IdleBehaviour.cs" />
     <Compile Include="Behaviours\TriggerComparer.cs" />

--- a/MonikAI/packages.config
+++ b/MonikAI/packages.config
@@ -5,4 +5,5 @@
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net452" />
   <package id="Octokit" version="0.29.0" targetFramework="net452" />
   <package id="TaskScheduler" version="2.7.3" targetFramework="net47" />
+  <package id="uHttpSharp" version="0.1.6.22" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
Basically MonikAI run a http server that listen to 127.0.0.1:82
A (Grease/Tamper)monkey script running in the browser will send PUT http request to ^ address with the data being the url of a loaded webpage